### PR TITLE
Pass ndimx = 7 to dat_shape

### DIFF
--- a/lib/PDL/IO/NDF.pm.PL
+++ b/lib/PDL/IO/NDF.pm.PL
@@ -985,7 +985,7 @@ sub find_prim {
   return  $status if $status != &NDF::SAI__OK;
 
   # Most dimensions
-  $maxdims = 100;
+  $maxdims = 7;
 
   # Is it a primitive component
   dat_prim($loc, $prim, $status);
@@ -1074,7 +1074,7 @@ sub find_prim {
   } else {
 
     my ($ndimx, @dim, $ndim);
-    dat_shape($loc, 20, \@dim, $ndim, $status);
+    dat_shape($loc, 7, \@dim, $ndim, $status);
 
     # If we have a single dimension ($ndim=0) then
     # proceed. Cant yet cope with multi-dimensional


### PR DESCRIPTION
This module's tests fail when being built with a version of Starlink
including HDS-v5.  Passing ndimx > DAT__MXDIM to dat_shape is giving a
segmentation fault because hds_select's datShape is writing beyond
the size of a temporary array allocated by the fortran interface's
DAT_SHAPE.